### PR TITLE
fix: dependabot junit group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,6 @@ updates:
     open-pull-requests-limit: 10
     assignees:
       - kazkansouh
+    groups:
+      org.junit.jupiter:
+        patterns: ["org.junit.jupiter:*"]


### PR DESCRIPTION
Update dependabot config to update `org.junit.jupiter` packages at same time.